### PR TITLE
Change patch mtls command to use new Istio operator field

### DIFF
--- a/docs/istio/_index.md
+++ b/docs/istio/_index.md
@@ -40,7 +40,7 @@ We support the following three scenarios:
     - With `kubectl`:
 
         ```bash
-        kubectl patch istio -n istio-system mesh --type=json -p='[{"op": "replace", "path": "/spec/mtls", "value":true}]'
+        kubectl patch istio -n istio-system mesh --type=json -p='[{"op": "replace", "path": "/spec/meshPolicy/mtlsMode", "value":STRICT}]'
         ```
 
     - With `backyards`:


### PR DESCRIPTION
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

There is a new field now in the Istio Operator CR spec to configure mesh wide mTLS settings: https://github.com/banzaicloud/istio-operator/pull/369/commits/2104cd30cf7928c9de9e9dc8f5ef336af5936b34

In the new Backyards 1.2 release this Istio operator version is used now, hence this PR to adjust to setting the new `meshPolicy.mtlsMode` field instead of the deprecated `mtls` one.