### PR TITLE
Update docs to include correct secret manifest. Existing example does…

### DIFF
--- a/docs/mutating-webhook/_index.md
+++ b/docs/mutating-webhook/_index.md
@@ -38,15 +38,19 @@ The webhook checks if a container has *envFrom* and parses the defined ConfigMap
               name: aws-key-configmap
 ```
 
-Secret and ConfigMap examples:
+### Secret and ConfigMap examples:
 
+Secrets require their payload be base64 encoded by definition and the API will reject manifests with plaintext in them.
+The secret value should contain a base64 encoded template string referencing the vault path you want to insert.
+Run `echo -n "vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY" | base64` to get the correct string. 
+  
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
   name: aws-key-secret
 data:
-  AWS_SECRET_ACCESS_KEY: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+  AWS_SECRET_ACCESS_KEY: dmF1bHQ6c2VjcmV0L2RhdGEvYWNjb3VudHMvYXdzI0FXU19TRUNSRVRfQUNDRVNTX0tFWQ==
 type: Opaque
 ```
 


### PR DESCRIPTION
Example as described does not work due to manifest validation requiring secret payloads be base64 encoded.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
We ran into issues deploying secrets as described in the documentation, they do not pass validation when running `kubectl apply -f <secret-manifest>.yaml`

### Why?
This PR contains an elaboration on what should be in the secret yaml definition and explains how to do so. 

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Current setup as described in example was deployed in production. Works as intended with encoded secret val. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ x ] User guide and development docs updated (if needed)
- [ / ] Related Helm chart(s) updated (if needed)
