### PR TITLE
Webhook monitoring

### DIFF
--- a/docs/monitoring/_index.md
+++ b/docs/monitoring/_index.md
@@ -11,3 +11,5 @@ At Banzai Cloud we prefer Prometheus for monitoring and use it also for Vault. I
 ```
 
 You may find the [generic Prometheus kubernetes client Go Process runtime monitoring dashboard](https://grafana.com/grafana/dashboards/240) useful for monitoring the webhook or any other Go process.
+
+To monitor the [mutating webhook](/docs/bank-vaults/mutating-webhook/), see {{% xref "/docs/bank-vaults/mutating-webhook/monitoring.md" %}}.

--- a/docs/mutating-webhook/monitoring.md
+++ b/docs/mutating-webhook/monitoring.md
@@ -37,8 +37,14 @@ To monitor the webhook with Prometheus and Grafana, complete the following steps
 1. Create a Grafana instance and expose it:
 
     ```bash
-    kubectl run grafana --image grafana/grafana
+    kubectl create deployment grafana --image grafana/grafana
     kubectl expose deployment grafana --port 3000 --type LoadBalancer
+    ```
+
+1. Fetch the external IP address of the Grafana instance, and open it in your browser on port 3000.
+
+    ```bash
+    kubectl get service grafana
     ```
 
 1. [Create a Prometheus Data Source](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source) in this Grafana instance which grabs data from http://prometheus-operated:9090/.

--- a/docs/mutating-webhook/monitoring.md
+++ b/docs/mutating-webhook/monitoring.md
@@ -4,36 +4,45 @@ shortTitle: Monitoring
 weight: 300
 ---
 
-Install the webhook with monitoring and Prometheus Operator ServiceMonitor enabled:
+To monitor the webhook with Prometheus and Grafana, complete the following steps.
 
-```bash
-helm upgrade --wait --install vault-secrets-webhook \
-    ./charts/vault-secrets-webhook \
-    --namespace vault-infra \
-    --set metrics.enabled=true \
-    --set metrics.serviceMonitor.enabled=true
-```
+## Prerequisites
 
-Install the Prometheus Operator Bundle:
+- An already deployed and configured mutating webhook. For details, see {{% xref "/docs/bank-vaults/mutating-webhook/_index.md" %}}
 
-```bash
-kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml
-```
+## Steps
 
-Create a Prometheus instance which monitors the Bank-Vaults components:
+1. Install the Prometheus Operator Bundle:
 
-```bash
-kubectl apply -f ./hack/prometheus.yaml
-```
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/bundle.yaml
+    ```
 
-Create a Grafana instance instance and expose it:
+1. Install the webhook with monitoring and Prometheus Operator ServiceMonitor enabled:
 
-```bash
-kubectl run grafana --image grafana/grafana
-kubectl expose deployment grafana --port 3000 --type LoadBalancer
-```
+    ```bash
+    helm upgrade --wait --install vault-secrets-webhook \
+        banzaicloud-stable/vault-secrets-webhook \
+        --namespace vault-infra \
+        --set metrics.enabled=true \
+        --set metrics.serviceMonitor.enabled=true
+    ```
 
-Create a Prometheus Data Source in this Grafana instance which grabs data from http://prometheus-operated:9090/.
+1. Create a Prometheus instance which monitors the components of Bank-Vaults:
 
-Import the [Kubewebhook admission webhook dashboard](https://grafana.com/grafana/dashboards/7088) to Grafana by Xabier Larrakoetxea.
-Select the previously create Data Source to feed this dashboard.
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/hack/prometheus.yaml
+    ```
+
+1. Create a Grafana instance and expose it:
+
+    ```bash
+    kubectl run grafana --image grafana/grafana
+    kubectl expose deployment grafana --port 3000 --type LoadBalancer
+    ```
+
+1. [Create a Prometheus Data Source](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source) in this Grafana instance which grabs data from http://prometheus-operated:9090/.
+
+1. [Import](https://prometheus.io/docs/visualization/grafana/#importing-pre-built-dashboards-from-grafana-com) the [Kubewebhook admission webhook dashboard](https://grafana.com/grafana/dashboards/7088) to Grafana (created by Xabier Larrakoetxea).
+
+1. Select the previously created Data Source to feed this dashboard.

--- a/docs/mutating-webhook/monitoring.md
+++ b/docs/mutating-webhook/monitoring.md
@@ -25,7 +25,7 @@ To monitor the webhook with Prometheus and Grafana, complete the following steps
         banzaicloud-stable/vault-secrets-webhook \
         --namespace vault-infra \
         --set metrics.enabled=true \
-        --set metrics.serviceMonitor.enabled=true
+        --set metrics.serviceMonitor.enabled={}
     ```
 
 1. Create a Prometheus instance which monitors the components of Bank-Vaults:

--- a/docs/mutating-webhook/monitoring.md
+++ b/docs/mutating-webhook/monitoring.md
@@ -8,7 +8,7 @@ To monitor the webhook with Prometheus and Grafana, complete the following steps
 
 ## Prerequisites
 
-- An already deployed and configured mutating webhook. For details, see {{% xref "/docs/bank-vaults/mutating-webhook/_index.md" %}}
+- An already deployed and configured mutating webhook. For details, see {{% xref "/docs/bank-vaults/mutating-webhook/_index.md" %}}.
 
 ## Steps
 


### PR DESCRIPTION
Hi @bonifaido, I tried to cleanup and test the webhook monitoring docs, but the `kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/hack/prometheus.yaml` command fails with the following error message: 
```
error: error validating "https://raw.githubusercontent.com/banzaicloud/bank-vaults/master/hack/prometheus.yaml": error validating data: ValidationError(Prometheus.spec.serviceMonitorNamespaceSelector): unknown field "any" in com.coreos.monitoring.v1.Prometheus.spec.serviceMonitorNamespaceSelector; if you choose to ignore these errors, turn validation off with --validate=false
```

I believe it's this issue: https://github.com/helm/charts/issues/20581
Do you have any ideas for how to solve it properly?