### PR TITLE
Fix incorrect YAML indentation in Bank Vaults docs regarding Istio

### DIFF
--- a/docs/istio/_index.md
+++ b/docs/istio/_index.md
@@ -57,12 +57,12 @@ We support the following three scenarios:
         apiVersion: authentication.istio.io/v1alpha1
         kind: MeshPolicy
         metadata:
-        name: default
-        labels:
+          name: default
+          labels:
             app: security
         spec:
-        peers:
-        - mtls: {}
+          peers:
+          - mtls: {}
         ```
 
     - With `backyards`:
@@ -93,16 +93,16 @@ Now your cluster is properly running on Istio with mTLS enabled globally.
         apiVersion: authentication.istio.io/v1alpha1
         kind: Policy
         metadata:
-        name: vault-secrets-webhook
-        namespace: vault-system
-        labels:
+          name: vault-secrets-webhook
+          namespace: vault-system
+          labels:
             app: security
         spec:
-        targets:
-        - name: vault-secrets-webhook
-        peers:
-        - mtls:
-            mode: PERMISSIVE
+          targets:
+          - name: vault-secrets-webhook
+          peers:
+          - mtls:
+              mode: PERMISSIVE
         EOF
         ```
 

--- a/docs/istio/vault-outside-the-mesh.md
+++ b/docs/istio/vault-outside-the-mesh.md
@@ -43,14 +43,14 @@ First, complete the {{% xref "/docs/bank-vaults/istio/_index.md#prerequisites" %
         apiVersion: authentication.istio.io/v1alpha1
         kind: Policy
         metadata:
-        name: default
-        namespace: vault
-        labels:
+          name: default
+          namespace: vault
+          labels:
             app: security
         spec:
-        peers:
-        - mtls:
-            mode: PERMISSIVE
+          peers:
+          - mtls:
+              mode: PERMISSIVE
         EOF
         ```
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

Indentation fix in example Kubernetes manifests

### Why?

Example manifests included in documentation are not valid and will not apply. Maybe the indentation was lost during copy and paste. My changes mean these manifests are now valid and will apply cleanly.

### Checklist

- [x] User guide and development docs updated (if needed)


### results before

(note that [authentication.istio.io/v1alpha1 was replaced in Istio >= 1.6 with v1beta1](https://istio.io/latest/news/releases/1.6.x/announcing-1.6/upgrade-notes/), but that's a separate issue - here I have tested with Istio 1.5)

```shell
$ kubectl apply -f - <<EOF
> apiVersion: authentication.istio.io/v1alpha1
> kind: Policy
> metadata:
> name: default
> namespace: vault
> labels:
>     app: security
> spec:
> peers:
> - mtls:
>     mode: PERMISSIVE
> EOF
error: error validating "STDIN": error validating data: [unknown object type "nil" in Policy.metadata, unknown object type "nil" in Policy.spec]; if you choose to ignore these errors, turn validation off with --validate=false
```

### results after indentation fix

```shell
$ kubectl apply -f - <<EOF
> apiVersion: authentication.istio.io/v1alpha1
> kind: Policy
> metadata:
>   name: default
>   namespace: vault
>   labels:
>     app: security
> spec:
>   peers:
>   - mtls:
>       mode: PERMISSIVE
> EOF
policy.authentication.istio.io/default created
```