### PR TITLE
Backup-docs: Update velero plugin

### DIFF
--- a/docs/backup/_index.md
+++ b/docs/backup/_index.md
@@ -47,7 +47,7 @@ To configure the vault-operator to create backups of the Vault cluster, complete
                   --set configuration.volumeSnapshotLocation.name=aws \
                   --set configuration.volumeSnapshotLocation.config.region=${REGION} \
                   --set "initContainers[0].name"=velero-plugin-for-aws \
-                  --set "initContainers[0].image"=velero/velero-plugin-for-aws:v1.0.0 \
+                  --set "initContainers[0].image"=velero/velero-plugin-for-aws:v1.2.1 \
                   --set "initContainers[0].volumeMounts[0].mountPath"=/target \
                   --set "initContainers[0].volumeMounts[0].name"=plugins \
                   vmware-tanzu/velero


### PR DESCRIPTION
The docs currently to use a working but dated velero plugin.

1.2.1 just got released and it contains fixes for CVE-2021-3121 and CVE-2021-3580

https://github.com/vmware-tanzu/velero-plugin-for-aws/releases/tag/v1.2.1

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

