### PR TITLE
Add documentation for service account

### DIFF
--- a/docs/mutating-webhook/annotations.md
+++ b/docs/mutating-webhook/annotations.md
@@ -25,5 +25,6 @@ The mutating webhook adds the following PodSpec, Secret, ConfigMap, and CRD anno
 `vault.security.banzaicloud.io/vault-env-from-path`|`""`|Comma-delimited list of vault paths to pull in all secrets as environment variables|
 `vault.security.banzaicloud.io/token-auth-mount`|`""`|`{volume:file}` to be injected as `.vault-token`. |
 `vault.security.banzaicloud.io/vault-auth-method`|`"kubernetes"`| The [Vault authentication method](https://www.vaultproject.io/docs/auth) to be used, one of `["kubernetes", "aws-ec2", "gcp-gce", "jwt"]`|
+`vault.security.banzaicloud.io/vault-serviceaccount`|`""`| The ServiceAccount in the objects namespace to use, useful for non-pod resources |
 `vault.security.banzaicloud.io/vault-namespace`|`""`|The [Vault Namespace](https://www.vaultproject.io/docs/enterprise/namespaces) secrets will be pulled from.  This annotation sets the `VAULT_NAMESPACE` environment variable. More information on `namespaces` within Vault can be found [here](https://learn.hashicorp.com/tutorials/vault/namespaces)|
 


### PR DESCRIPTION
Relates to https://github.com/banzaicloud/bank-vaults/pull/1401

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     |  no
| Deprecations?   | no
| Related tickets |  partially https://github.com/banzaicloud/bank-vaults/pull/1401
| License         | Apache 2.0


### What's in this PR?
Documentation for the https://github.com/banzaicloud/bank-vaults/pull/1401 PR

### Why?
Usage of ServiceAccounts with  non-Pod resources


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)
